### PR TITLE
Add gold medals history page and navigation

### DIFF
--- a/gold-medals.html
+++ b/gold-medals.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Jess's Gold Medals</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans:wght@400;500;700;900&amp;family=Space+Grotesk:wght@400;500;700"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  </head>
+  <body class="bg-[#111618] text-white" style='font-family: "Space Grotesk", "Noto Sans", sans-serif;'>
+    <div class="min-h-screen flex flex-col items-center justify-center px-6 py-12">
+      <div class="max-w-2xl w-full flex flex-col gap-6 text-center">
+        <h1 class="text-3xl font-bold tracking-tight">Jess's Gold Medal History</h1>
+        <p class="text-[#9db0b9] text-base">
+          These are the years Jess captured her gold medals on the world stage.
+        </p>
+        <ul class="flex flex-col gap-3">
+          <li class="rounded-lg border border-[#3b4b54] px-6 py-4 text-lg font-semibold">2012</li>
+          <li class="rounded-lg border border-[#3b4b54] px-6 py-4 text-lg font-semibold">2013</li>
+          <li class="rounded-lg border border-[#3b4b54] px-6 py-4 text-lg font-semibold">2017</li>
+        </ul>
+        <a href="index.html" class="text-[#4fb3ff] text-sm font-medium underline">Back to performance dashboard</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -41,10 +41,15 @@
                 <p class="text-white tracking-light text-2xl font-bold leading-tight">12</p>
                 <div class="flex items-center gap-2"><p class="text-[#9db0b9] text-sm font-normal leading-normal">World Cup Wins</p></div>
               </div>
-              <div class="flex min-w-[111px] flex-1 basis-[fit-content] flex-col gap-2 rounded-lg border border-[#3b4b54] p-3 items-start">
+              <a
+                href="gold-medals.html"
+                class="flex min-w-[111px] flex-1 basis-[fit-content] flex-col gap-2 rounded-lg border border-[#3b4b54] p-3 items-start hover:border-[#4fb3ff] transition-colors"
+              >
                 <p class="text-white tracking-light text-2xl font-bold leading-tight">3</p>
-                <div class="flex items-center gap-2"><p class="text-[#9db0b9] text-sm font-normal leading-normal">Olympic Medals</p></div>
-              </div>
+                <div class="flex items-center gap-2">
+                  <p class="text-[#9db0b9] text-sm font-normal leading-normal underline decoration-dotted">Gold Medals</p>
+                </div>
+              </a>
               <div class="flex min-w-[111px] flex-1 basis-[fit-content] flex-col gap-2 rounded-lg border border-[#3b4b54] p-3 items-start">
                 <p class="text-white tracking-light text-2xl font-bold leading-tight">2</p>
                 <div class="flex items-center gap-2"><p class="text-[#9db0b9] text-sm font-normal leading-normal">World Championship Titles</p></div>


### PR DESCRIPTION
## Summary
- link the Gold Medals stat on the dashboard to a dedicated details page
- add a gold medals history page outlining the medal-winning years

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd799afa78832b8ec289ffac812b79